### PR TITLE
Use the `atom-workspace` tag instead of the `workspace` class.

### DIFF
--- a/keymaps/color-gutter.cson
+++ b/keymaps/color-gutter.cson
@@ -1,5 +1,5 @@
-'.platform-darwin .workspace':
+'.platform-darwin atom-workspace':
   'cmd-alt-g': 'color-gutter:toggle'
 
-'.platform-win32 .workspace, .platform-linux .workspace':
+'.platform-win32 atom-workspace, .platform-linux atom-workspace':
   'ctrl-alt-g': 'color-gutter:toggle'


### PR DESCRIPTION
Fix the warning 'Deprecated selectors'